### PR TITLE
Raimundo/tocid hoc

### DIFF
--- a/specs/index.bs
+++ b/specs/index.bs
@@ -609,6 +609,8 @@ The Data Type <{TCE}> models information related to a single [=Transport Chain E
 
 The Data Type <{TCE}> has the following properties:
 
+Note: The properties `tocId` and `hocId` are mutually exclusive, but one of them MUST be defined.
+
 <figure id="tce-properties-table" dfn-type="element-attr" dfn-for="TCE">
   <table class="data">
     <thead>


### PR DESCRIPTION
Due to whitespace the diff is hard to read, but the relevant changes are in lines

127 (adds link to the definition of host system); and
606 (adds note about `tocId` vs `hocId`