### PR TITLE
feat: update `energyConsumption` and  `energyConsumptionUnit` definitions

### DIFF
--- a/specs/index.bs
+++ b/specs/index.bs
@@ -1410,7 +1410,7 @@ The following properties are defined for data type <dfn element>EnergyCarrier</d
         <td>O
         <td>
             Unit of the energy consumed corresponding to the <{EnergyCarrier/energyConsumption}> (e.g., `"l"`, `"kg"`, `"kWh"`, `"MJ"`).
-            If defined, <{EnergyCarrier/energyConsumption}> MUST be defined as well.
+           <{EnergyCarrier/energyConsumptionUnit}> MUST be defined if <{EnergyCarrier/energyConsumption}> is defined.
       <tr>
         <td><dfn>co2eIntensityWTW</dfn> : [=Decimal=]
         <td>String

--- a/specs/index.bs
+++ b/specs/index.bs
@@ -1402,13 +1402,15 @@ The following properties are defined for data type <dfn element>EnergyCarrier</d
         <td>String
         <td>O
         <td>
-            Amount of energy carrier consumed per transport activity, as defined for the TOC or HOC.
+            Amount of energy carrier consumed per transport activity, as defined for the TOC or HOC. If defined, <{EnergyCarrier/energyConsumptionUnit}>
+            MUST be defined as well.
       <tr>
         <td><dfn>energyConsumptionUnit</dfn>
         <td>String
         <td>O
         <td>
-            Unit of the energy consumed corresponding to the (<{EnergyCarrier/energyConsumption}>). (l, kg, kWh, MJ)
+            Unit of the energy consumed corresponding to the <{EnergyCarrier/energyConsumption}> (e.g., `"l"`, `"kg"`, `"kWh"`, `"MJ"`).
+            If defined, <{EnergyCarrier/energyConsumption}> MUST be defined as well.
       <tr>
         <td><dfn>co2eIntensityWTW</dfn> : [=Decimal=]
         <td>String


### PR DESCRIPTION
This PR "bundles" the definitions of `energyConsumption` and `energyConsumptionUnit`, ensuring that defining one entails defining the other.

<img width="814" alt="Screenshot 2024-02-27 at 11 20 10" src="https://github.com/sine-fdn/ileap-extension/assets/100690574/8ef18566-9b83-4be6-9692-4c5b2eb09735">
