### PR TITLE
fix: changelog entry of consultation draft

### DIFF
--- a/specs/index.bs
+++ b/specs/index.bs
@@ -2004,7 +2004,7 @@ Note: Section [[#appendix-b-toc-example]] contains an example.
 
 # Appendix A: Changelog # {#changelog}
 
-## Version 0.2.0 (2024-05-21) ## {version-0.2.0}
+## Version 0.2.0 Consultation Draft (2024-05-21) ## {#version-0.2.0}
 
 Release Consultation Draft
 


### PR DESCRIPTION
This fixes a formatting bug with the consultation draft release:

<img width="363" alt="Screenshot 2024-05-21 at 22 48 16" src="https://github.com/sine-fdn/ileap-extension/assets/38831/de21a367-d6c5-45c0-89eb-94366e1d565c">
