### PR TITLE
Fuel Emission factor

### DIFF
--- a/specs/index.bs
+++ b/specs/index.bs
@@ -1502,13 +1502,13 @@ The following properties are defined for data type <dfn element>EnergyCarrier</d
             Unit of the energy consumed corresponding to the <{EnergyCarrier/energyConsumption}> (e.g., `"l"`, `"kg"`, `"kWh"`, `"MJ"`).
            <{EnergyCarrier/energyConsumptionUnit}> MUST be defined if <{EnergyCarrier/energyConsumption}> is defined.
       <tr>
-        <td><dfn>co2eIntensityWTW</dfn> : [=Decimal=]
+        <td><dfn>emsFactorWTW</dfn> : [=Decimal=]
         <td>String
         <td>M
         <td>
             The WTW fuel emission factor (certified) with unit `kgCO2e / energy consumption unit` (<{EnergyCarrier/energyConsumptionUnit}>)
       <tr>
-        <td><dfn>co2eIntensityTTW</dfn> : [=Decimal=]
+        <td><dfn>emissionFactorTTW</dfn> : [=Decimal=]
         <td>String
         <td>M
         <td>

--- a/specs/index.bs
+++ b/specs/index.bs
@@ -1502,7 +1502,7 @@ The following properties are defined for data type <dfn element>EnergyCarrier</d
             Unit of the energy consumed corresponding to the <{EnergyCarrier/energyConsumption}> (e.g., `"l"`, `"kg"`, `"kWh"`, `"MJ"`).
            <{EnergyCarrier/energyConsumptionUnit}> MUST be defined if <{EnergyCarrier/energyConsumption}> is defined.
       <tr>
-        <td><dfn>emsFactorWTW</dfn> : [=Decimal=]
+        <td><dfn>emissionFactorWTW</dfn> : [=Decimal=]
         <td>String
         <td>M
         <td>


### PR DESCRIPTION
Using GLEC Fw wording for referring to the ems intensity of the fuel in the energy carrier data type. - This avoids confusion with co2eIntensity at the TOC level & aligns better with GLEC terminology