### PR TITLE
Adding accreditation & validation to the TCE data type

### DIFF
--- a/specs/index.bs
+++ b/specs/index.bs
@@ -700,6 +700,18 @@ Note: The properties `tocId` and `hocId` are mutually exclusive, but one of them
         <td>O
         <td>The [=consignment id=] of the consignment related to the shipment related to this <{TCE}>
 
+     <tr>
+        <td><dfn>isVerified</dfn>
+        <td>Boolean
+        <td>M
+        <td>Indicates that the truthfulness of the GHG emissions value and related variables has been confirmed by a Validation and Verification Body (VVB), as declared in a Verification Statement. The VVB must follow a widely recognized standard for their GHG verification services (example: the ISO or ISAE standards). Verification should use [[!ISO14083]] as audit criteria.
+
+      <tr>
+        <td><dfn>isAccredited</dfn>
+        <td>Boolean
+        <td>M
+        <td>(=certified)Indicates that the calculation methodology has been evaluated as compliant with [[!ISO14083]]:2023, as declared in an Accreditation (=Certification) certificate.
+
       <tr>
         <td><dfn>mass</dfn> : [=Decimal=]
         <td>String


### PR DESCRIPTION
Adding accreditation & validation, as the calculations done at the TCE level should also be verified, even if they are based on data already verified at the TOC level