### PR TITLE
feat: happened-before TCE ordering relativ to the ShipmentFootprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ specs/index.html
 gen/target
 out/
 *.svg
+node_modules/
+package*.json

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,26 @@
 RELEASE_DIR:=out
+MMDC := ./node_modules/.bin/mmdc
+DIAGRAMS := $(patsubst %.mmd,%.svg,$(wildcard specs/diagrams/*.mmd))
 
 build: specs/index.html
 	mkdir -p ${RELEASE_DIR}
 	cp -r $< specs/diagrams ${RELEASE_DIR}/
 	cp -r TR ${RELEASE_DIR}/
 
-specs/index.html: specs/index.bs
+specs/index.html: specs/index.bs ${DIAGRAMS}
 	bikeshed spec $< $@
 
-serve:
+serve: ${DIAGRAMS}
 	cd specs && bikeshed serve
+
+clean:
+	rm -f ${DIAGRAMS}
+
+
+%.svg: %.mmd ${MMDC}
+	${MMDC} -i $< -o $@
+
+${MMDC}:
+	npm install @mermaid-js/mermaid-cli
 
 .PHONY: serve build

--- a/gen/schemas/shipment-footprint.json
+++ b/gen/schemas/shipment-footprint.json
@@ -385,6 +385,15 @@
             }
           ]
         },
+        "prevTceIds": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "shipmentId": {
           "type": "string"
         },

--- a/gen/src/lib.rs
+++ b/gen/src/lib.rs
@@ -27,6 +27,8 @@ pub struct NonEmptyVec<T>(pub Vec<T>);
 pub struct Tce {
     pub tce_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub prev_tce_ids: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub toc_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hoc_id: Option<String>,

--- a/gen/tests/tests.rs
+++ b/gen/tests/tests.rs
@@ -88,7 +88,7 @@ fn test_toc_deser() {
 #[test]
 fn test_ship_foot_deser() {
     let (json, expected) = (
-        r#"{"mass":"87","shipmentId":"1237890","tces":[{"tceId":"abcdef","tocId":"truck-40t-euro5-de","shipmentId":"1237890","mass":"87","distance":{"actual":"423"},"transportActivity":"36.801","co2eWTW":"36.801","co2eTTW":"3.2801"}]}"#,
+        r#"{"mass":"87","shipmentId":"1237890","tces":[{"tceId":"abcdef", "prevTceIds": [], "tocId":"truck-40t-euro5-de","shipmentId":"1237890","mass":"87","distance":{"actual":"423"},"transportActivity":"36.801","co2eWTW":"36.801","co2eTTW":"3.2801"}]}"#,
         ShipmentFootprint {
             mass: "87".to_string(),
             volume: None,
@@ -97,6 +97,7 @@ fn test_ship_foot_deser() {
             shipment_id: "1237890".to_string(),
             tces: NonEmptyVec::<Tce>::from(vec![Tce {
                 tce_id: "abcdef".to_string(),
+                prev_tce_ids: Some(vec![]),
                 toc_id: Some("truck-40t-euro5-de".to_string()),
                 hoc_id: None,
                 shipment_id: "1237890".to_string(),

--- a/specs/diagrams/tce-ordering.mmd
+++ b/specs/diagrams/tce-ordering.mmd
@@ -1,0 +1,38 @@
+---
+config:
+    theme: forest
+---
+flowchart LR
+
+    subgraph Initial Legs
+        TCE1("`TCE
+        ID=tce1234
+        prevTceIds=[]
+        `")
+
+        TCE2("`TCE
+        ID=tce567
+        prevTceIds=[]
+        `")
+    end
+
+    TCE3("`TCE
+    ID=tce890
+    prevTceIds=
+        [tce1234, tce567]
+    `")
+
+    TCE4("`TCE
+    ID=tceABC
+    prevTceIds=
+        [tce890]
+    `")
+
+    subgraph Transport to Rotterdam
+        TCE1-->TCE3
+        TCE2-->TCE3
+    end
+
+    subgraph Hub Operations
+        TCE3-->TCE4
+    end

--- a/specs/index.bs
+++ b/specs/index.bs
@@ -692,7 +692,7 @@ the <{ShipmentFootprint}> data type and the Pathfinder Data Exchange Protocol. S
 
 For reasons of transparency, traceability, auditability, and comprehensibility,
 the recipients of TCE data ([=Transport Service User=] or [=Transport Service Organizer=]) SHOULD also receive the information
-on the order in which they TCEs occurred during the transport of the shipment.
+on the order in which the TCEs occurred during the transport of the shipment.
 
 Order here means "happens-before" relationship between TCEs relative to other TCEs of the same <{ShipmentFootprint}>.
 

--- a/specs/index.bs
+++ b/specs/index.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: iLEAP Technical Specifications (Version 0.2.1-20240618)
+Title: iLEAP Technical Specifications (Version 0.2.1-20240702)
 Shortname: ileap-extension
 Status: LD
 Status Text: Draft Technical Specification
@@ -2136,9 +2136,9 @@ Note: Section [[#appendix-b-toc-example]] contains an example.
 
 # Appendix A: Changelog # {#changelog}
 
-## Version 0.2.1-20240618 (2024-06-18) ## {#version-20240618}
+## Version 0.2.1-20240702 (2024-07-02) ## {#version-20240702}
 
-- New "feature": happened-before relationship between <{TCE|TCEs}> relative to a single shipment and <{ShipmentFootprint}>, enabled through the new property <{TCE/prevTceIds}>. 
+- New "feature": OPTIONAL happened-before relationship between <{TCE|TCEs}> relative to a single shipment and <{ShipmentFootprint}>, enabled through the new property <{TCE/prevTceIds}>. 
 - Addition of the guidance chapter [[#tce-ordering]] to define the <{TCE/prevTceIds}> semantics
 
 

--- a/specs/index.bs
+++ b/specs/index.bs
@@ -696,8 +696,9 @@ on the order in which they TCEs occurred during the transport of the shipment.
 
 Order here means "happens-before" relationship between TCEs relative to other TCEs of the same <{ShipmentFootprint}>.
 
-To facilitate this, the data model of TCEs includes the property <{TCE/prevTceIds}>. If defined, <{TCE/prevTceIds}> MUST reference all the IDs (<{TCE/tceId}>) of the TCEs which happened before the current TCE.
-If the property is empty, the current TCE is the first TCE of the shipment.
+To facilitate this, the data model of TCEs includes the property <{TCE/prevTceIds}>.
+If defined, <{TCE/prevTceIds}> MUST reference all the IDs (<{TCE/tceId}>) of the TCEs which happened *immediately* before the current TCE and <{ShipmentFootprint}>.
+If the property is empty, the current TCE is the first TCE of the shipment in relation to the <{ShipmentFootprint}>.
 
 <div class=example>
 

--- a/specs/index.bs
+++ b/specs/index.bs
@@ -691,14 +691,15 @@ the <{ShipmentFootprint}> data type and the Pathfinder Data Exchange Protocol. S
 ### Ordering of TCEs ### {#tce-ordering}
 
 For reasons of transparency, traceability, auditability, and comprehensibility,
-the recipients of TCE data ([=Transport Service User=] or [=Transport Service Organizer=]) MUST also receive the information
+the recipients of TCE data ([=Transport Service User=] or [=Transport Service Organizer=]) SHOULD also receive the information
 on the order in which they TCEs occurred during the transport of the shipment.
 
 Order here means "happens-before" relationship between TCEs relative to other TCEs of the same <{ShipmentFootprint}>.
 
 To facilitate this, the data model of TCEs includes the property <{TCE/prevTceIds}>.
+
 If defined, <{TCE/prevTceIds}> MUST reference all the IDs (<{TCE/tceId}>) of the TCEs which happened *immediately* before the current TCE and <{ShipmentFootprint}>.
-If the property is empty, the current TCE is the first TCE of the shipment in relation to the <{ShipmentFootprint}>.
+If the property is defined and the array is empty, the current TCE MUST be the first TCE of the shipment in relation to the <{ShipmentFootprint}>.
 
 <div class=example>
 
@@ -744,9 +745,9 @@ Note: The properties `tocId` and `hocId` are mutually exclusive, but one of them
       <tr>
         <td><dfn>prevTceIds</dfn>
         <td>String[]
-        <td>M
+        <td>O
         <td>
-              The <{TCE/tceId|tceIds}> of [=Transport Chain Element=] preceding the current TCE. If empty, the current TCE is the first TCE.
+              If defined, the <{TCE/tceId|tceIds}> of [=Transport Chain Element=] preceding the current TCE.
               See [[#tce-ordering]] for more information.
 
       <tr>

--- a/specs/index.bs
+++ b/specs/index.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: iLEAP Technical Specifications (Version 0.2.1-20240611)
+Title: iLEAP Technical Specifications (Version 0.2.1-20240618)
 Shortname: ileap-extension
 Status: LD
 Status Text: Draft Technical Specification
@@ -478,6 +478,7 @@ The highlighted lines show the data exchanged according to the <{ShipmentFootpri
             "tces": [
               {
                 "tceId": "abcdef",
+                "prevTceIds": [],
                 "tocId": "truck-40t-euro5-de",
                 "shipmentId": "1237890",
                 "mass": "87",
@@ -559,6 +560,7 @@ The highlighted lines show 2 TCEs which `Z` has collected and calculated for `S`
             "tces": [
               {
                 "tceId": "abcdef",
+                "prevTceIds": [],
                 "tocId": "truck-40t-euro5-de",
                 "shipmentId": "1237890",
                 "mass": "87",
@@ -571,6 +573,7 @@ The highlighted lines show 2 TCEs which `Z` has collected and calculated for `S`
               },
               {
                 "tceId": "ghijkl",
+                "prevTceIds": [ "abcdef" ],
                 "tocId": "operator-z-truck-89sdff",
                 "shipmentId": "1237890",
                 "mass": "87",
@@ -679,11 +682,35 @@ Issue: <{ShipmentFootprint/numberOfItems}> and <{ShipmentFootprint/typeOfItems}>
 
 The Data Type <{TCE}> models information related to a single [=Transport Chain Element=].
 
-[=TCEs=] are the building blocks to construct a Transport Chain ([=TC=]), enabling the calculation of logistics emissions.
+The data related to TCEs can be obtained from direct measurement (see [=Primary Data=]) or other measurements (see [=Secondary Data=]).
 
-Transport Chain Element Data can be obtained from direct measurement
-(see [=Primary Data=] or other measurements
-(see [=Secondary Data=]).
+<{TCE|TCEs}> are typically calculated by [=Transport Operators=] and [=Transport Service Organizers=]. They are made available to [=Transport Service Users=] through 
+the <{ShipmentFootprint}> data type and the Pathfinder Data Exchange Protocol. See [[#dt-sf]] and [[#pcf-mapping]] for details.
+
+
+### Ordering of TCEs ### {#tce-ordering}
+
+For reasons of transparency, traceability, auditability, and comprehensibility,
+the recipients of TCE data ([=Transport Service User=] or [=Transport Service Organizer=]) MUST also receive the information
+on the order in which they TCEs occurred during the transport of the shipment.
+
+Order here means "happens-before" relationship between TCEs relative to other TCEs of the same <{ShipmentFootprint}>.
+
+To facilitate this, the data model of TCEs includes the property <{TCE/prevTceIds}>. If defined, <{TCE/prevTceIds}> MUST reference all the IDs (<{TCE/tceId}>) of the TCEs which happened before the current TCE.
+If the property is empty, the current TCE is the first TCE of the shipment.
+
+<div class=example>
+
+  A [=Transport Service User=] procured the shipment of 2 containers to Rotterdam through a [=Transport Service Organizer=]. The organizer then makes a 
+  <{ShipmentFootprint}> available to the [=Transport Service User=], consisting of the following TCEs:
+
+  1. two TCEs with IDs `tce1234` and `tce567` for the first leg of the shipment, which is the transport of the 2 containers from the warehouse to the port.
+      For both TCEs, <{TCE/prevTceIds}> must equal `[]` (the empty array).
+  2. one TCE with ID `tce890` for the second leg of the shipment, which is the transport of the 2 containers from the port in Shanghai to the port of Rotterdam.
+      For this TCE, <{TCE/prevTceIds}> must equal `["tce1234", "tce567"]`.
+  3. And, last but not least, another TCE for the hub operations at Rotterdam. For this TCE, <{TCE/prevTceIds}> must equal `["tce890"]`.
+
+</div>
 
 
 ### Data Attributes ### {#tce-attributes}
@@ -706,6 +733,14 @@ Note: The properties `tocId` and `hocId` are mutually exclusive, but one of them
         <td>String
         <td>M
         <td>The id of the [=Transport Chain Element=]
+
+      <tr>
+        <td><dfn>prevTceIds</dfn>
+        <td>String[]
+        <td>M
+        <td>
+              The <{TCE/tceId|tceIds}> of [=Transport Chain Element=] preceding the current TCE. If empty, the current TCE is the first TCE.
+              See [[#tce-ordering]] for more information.
 
       <tr>
         <td><dfn>tocId</dfn>
@@ -2093,6 +2128,12 @@ Note: Section [[#appendix-b-toc-example]] contains an example.
 
 # Appendix A: Changelog # {#changelog}
 
+## Version 0.2.1-20240618 (2024-06-18) ## {#version-20240618}
+
+- New "feature": happened-before relationship between <{TCE|TCEs}> relative to a single shipment and <{ShipmentFootprint}>, enabled through the new property <{TCE/prevTceIds}>. 
+- Addition of the guidance chapter [[#tce-ordering]] to define the <{TCE/prevTceIds}> semantics
+
+
 ## Version 0.2.1-20240611 (2024-06-11) ## {#version-20240611}
 
 - addition of section [[#document-statuses]]
@@ -2212,6 +2253,7 @@ A Product Footprint with a <{ShipmentFootprint}> highlighted:
               "tces": [
                   {
                       "tceId": "abcdef",
+                      "prevTceIds": [],
                       "tocId": "truck-40t-euro5-de",
                       "shipmentId": "1237890",
                       "mass": "87",

--- a/specs/index.bs
+++ b/specs/index.bs
@@ -708,7 +708,13 @@ If the property is empty, the current TCE is the first TCE of the shipment.
       For both TCEs, <{TCE/prevTceIds}> must equal `[]` (the empty array).
   2. one TCE with ID `tce890` for the second leg of the shipment, which is the transport of the 2 containers from the port in Shanghai to the port of Rotterdam.
       For this TCE, <{TCE/prevTceIds}> must equal `["tce1234", "tce567"]`.
-  3. And, last but not least, another TCE for the hub operations at Rotterdam. For this TCE, <{TCE/prevTceIds}> must equal `["tce890"]`.
+  3. And, last but not least, another TCE with ID `tceABC` for the hub operations at Rotterdam. For this TCE, <{TCE/prevTceIds}> must equal `["tce890"]`.
+
+
+<figure>
+  <img src="diagrams/tce-ordering.svg" height="80%" width="80%" >
+  <figcaption>TCE happened-before relationship graph</figcaption>
+</figure>
 
 </div>
 

--- a/specs/index.bs
+++ b/specs/index.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: iLEAP Technical Specifications (Version 0.2.1-20240702)
+Title: iLEAP Technical Specifications (Version 0.2.1-20240708)
 Shortname: ileap-extension
 Status: LD
 Status Text: Draft Technical Specification
@@ -684,7 +684,7 @@ The Data Type <{TCE}> models information related to a single [=Transport Chain E
 
 The data related to TCEs can be obtained from direct measurement (see [=Primary Data=]) or other measurements (see [=Secondary Data=]).
 
-<{TCE|TCEs}> are typically calculated by [=Transport Operators=] and [=Transport Service Organizers=]. They are made available to [=Transport Service Users=] through 
+<{TCE|TCEs}> are typically calculated by [=Transport Operators=] and [=Transport Service Organizers=]. They are made available to [=Transport Service Users=] through
 the <{ShipmentFootprint}> data type and the Pathfinder Data Exchange Protocol. See [[#dt-sf]] and [[#pcf-mapping]] for details.
 
 
@@ -703,7 +703,7 @@ If the property is defined and the array is empty, the current TCE MUST be the f
 
 <div class=example>
 
-  A [=Transport Service User=] procured the shipment of 2 containers to Rotterdam through a [=Transport Service Organizer=]. The organizer then makes a 
+  A [=Transport Service User=] procured the shipment of 2 containers to Rotterdam through a [=Transport Service Organizer=]. The organizer then makes a
   <{ShipmentFootprint}> available to the [=Transport Service User=], consisting of the following TCEs:
 
   1. two TCEs with IDs `tce1234` and `tce567` for the first leg of the shipment, which is the transport of the 2 containers from the warehouse to the port.
@@ -2136,9 +2136,9 @@ Note: Section [[#appendix-b-toc-example]] contains an example.
 
 # Appendix A: Changelog # {#changelog}
 
-## Version 0.2.1-20240702 (2024-07-02) ## {#version-20240702}
+## Version 0.2.1-20240708 (2024-07-08) ## {#version-20240708}
 
-- New "feature": OPTIONAL happened-before relationship between <{TCE|TCEs}> relative to a single shipment and <{ShipmentFootprint}>, enabled through the new property <{TCE/prevTceIds}>. 
+- New "feature": OPTIONAL happened-before relationship between <{TCE|TCEs}> relative to a single shipment and <{ShipmentFootprint}>, enabled through the new property <{TCE/prevTceIds}>.
 - Addition of the guidance chapter [[#tce-ordering]] to define the <{TCE/prevTceIds}> semantics
 
 


### PR DESCRIPTION
This is a first proposal to add a "happened-before" relationship between TCEs, mitigated through the highlighted TCE property:

<img width="776" alt="Screenshot 2024-07-02 at 22 10 21" src="https://github.com/sine-fdn/ileap-extension/assets/38831/7be0dee7-1cce-4dd6-bbf1-c5b7cfbeef37">

This PR also adds a semantics chapter for this property: 

<img width="771" alt="Screenshot 2024-07-02 at 22 11 40" src="https://github.com/sine-fdn/ileap-extension/assets/38831/8047fc7e-ba82-447c-8d8a-5b86f7446424">


_Please note_:  This PR does not yet include changes to the data model implementation. Once agreement on this change is made, a follow-up PR will be made.