### PR TITLE
fix: mmdc call with `ubuntu-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+on: [push]
+
+name: CI
+
+jobs:
+  build_and_test:
+    name: Test Rust
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Bikeshed
+        run: pip3 install bikeshed && bikeshed update
+      - name: Build docs
+        run: make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,4 @@ jobs:
       - name: Install Bikeshed
         run: pip3 install bikeshed && bikeshed update
       - name: Build docs
-        run: make
+        run: aa-exec --profile=chrome make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ name: CI
 
 jobs:
   build_and_test:
-    name: Test Rust
+    name: Build Tech Specs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Bikeshed
         run: pip3 install bikeshed && bikeshed update
       - name: Build docs

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Bikeshed
         run: pip3 install bikeshed && bikeshed update
       - name: Build docs
-        run: make
+        run: aa-exec --profile=chrome make
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: [$default-branch]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -18,7 +18,7 @@ permissions:
 # Allow one concurrent deployment
 concurrency:
   group: "pages"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # Single deploy job since we're just deploying
@@ -26,21 +26,21 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
       - name: Install Bikeshed
         run: pip3 install bikeshed && bikeshed update
       - name: Build docs
         run: make
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: "out"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The mermaid-cli tool to generate diagrams calls into puppeteer. With the latest Ubuntu version, this fails for security reasons. This issue has a fix which we apply here: https://github.com/mermaid-js/mermaid-cli/issues/730