### PR TITLE
docs: remove properties `numberOfItems` and `typeOfItems` from `Shipmentfootprint`

### DIFF
--- a/specs/index.bs
+++ b/specs/index.bs
@@ -650,16 +650,6 @@ A <{ShipmentFootprint}> has the following properties:
         <td>O
         <td>The volume of the freight (SI Unit `cubic metre (CBM)`) and any packaging provided by the [=Transport Service User=].
       <tr>
-        <td><dfn>numberOfItems</dfn>
-        <td>Number
-        <td>O
-        <td>The number of units the shipment, including the goods transported and any packaging provided by the [=Transport Service User=], is composed of.
-      <tr>
-        <td><dfn>typeOfItems</dfn>
-        <td>String
-        <td>O
-        <td>The type of units the shipment, including the goods transported and any packaging provided by the [=Transport Service User=], is composed of. For example, boxes, pallets, bottles, etc.
-      <tr>
         <td><dfn>shipmentId</dfn>
         <td>String
         <td>M
@@ -2572,6 +2562,11 @@ apply for additional support, materials, and marketing opportunities.
 
 # Appendix A: Changelog # {#changelog}
 
+## Version 1.0.0-beta2 (2025-05-01) ## {#version-1.0.0-beta2}
+
+- removal of properties `numberOfItems` and `typeOfItems` from <{ShipmentFootprint}>
+
+
 ## Version 1.0.0-beta (2025-03-19) ## {#version-1.0.0-beta}
 
 - remove underspecified property `dataQualityIndex`
@@ -2631,7 +2626,7 @@ apply for additional support, materials, and marketing opportunities.
 
 - improved uniqueness definition in [=consignment id=] and [=shipment id=]
 - use [=Decimal=] data type consistently
-- add issues to <{ShipmentFootprint/numberOfItems}> and <{ShipmentFootprint/typeOfItems}> instead of
+- add issues to <{ShipmentFootprint}> properties `numberOfItems` and `typeOfItems` instead of
     common issue
 
 ## Version 0.2.1-20240716 (2024-07-16) ## {#version-20240716}

--- a/specs/index.bs
+++ b/specs/index.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: iLEAP Technical Specifications (Version 1.0.0-beta)
+Title: iLEAP Technical Specifications (Version 1.0.0-beta2)
 Shortname: ileap-extension
 Status: LD
 Status Text: Technical Specification Pre-Release
@@ -2562,10 +2562,9 @@ apply for additional support, materials, and marketing opportunities.
 
 # Appendix A: Changelog # {#changelog}
 
-## Version 1.0.0-beta2 (2025-05-01) ## {#version-1.0.0-beta2}
+## Version 1.0.0-beta2 (2025-05-06) ## {#version-1.0.0-beta2}
 
 - removal of properties `numberOfItems` and `typeOfItems` from <{ShipmentFootprint}>
-
 
 ## Version 1.0.0-beta (2025-03-19) ## {#version-1.0.0-beta}
 


### PR DESCRIPTION
The two properties are quite underdefined and almost "free form". 