### PR TITLE
1.0.1 Update

### DIFF
--- a/specs/index.bs
+++ b/specs/index.bs
@@ -2053,12 +2053,19 @@ With response parameters
 
 The Data types defined in [[#data-model]] are specific to [[!ISO14083]] and the [[!GLEC]] Framework.
 
-This section specifies the integration of the data types <{ShipmentFootprint}>, <{TOC}>, and <{HOC}> into the PACT Data Model ([[!PACTDX]] Chapter 4).
-The integration of the data types <{ShipmentFootprint}>, <{TOC}>, and <{HOC}> is achieved by storing them as extensions to the PACT Data Model (see [[!DATA-MODEL-EXTENSIONS]]).
-Therefore, all properties defined in the latter are also properties of the former. As a result, some properties relevant to logistics do not need to be defined in the [[#data-model]].
-The list below contains the properties that were omitted for this reason.
+This section specifies the integration of the data types <{ShipmentFootprint}>, <{TOC}>, and <{HOC}>
+into the PACT Data Model ([[!PACTDX]] Chapter 4). The integration of the data types
+<{ShipmentFootprint}>, <{TOC}>, and <{HOC}> is achieved by storing them as extensions to the PACT
+Data Model (see [[!DATA-MODEL-EXTENSIONS]]). Therefore, all properties defined in the latter are
+also properties of the former. As a result, some properties relevant to logistics do not need to be
+defined in the [[#data-model]]. The list below contains the properties that were omitted for this
+reason.
 
 Note: The extensions of one `ProductFootprint` CANNOT contain more than one iLEAP Data Type.
+
+Advisement: We are expecting methodological updates regarding (among others) biogenic emissions and
+black carbon. Once these updates are available, further guidance on how to represent them in the
+PACT Data Model will be provided.
 
 <figure id="ileap-pact-properties-mapping">
   <table class="data">
@@ -2782,7 +2789,8 @@ apply for additional support, materials, and marketing opportunities.
 
 Summary of changes:
 - addition of guidance on `secondaryEmissionFactorSources` in [[#pcf-mapping-sf]],
-  [[#pcf-mapping-toc]], and [[#pcf-mapping-hoc]]
+    [[#pcf-mapping-toc]], and [[#pcf-mapping-hoc]]
+- addition on advisment on future methodological updates and their implications to [[#pcf-mapping]]
 - fix typo in <{Location}> properties table
 
 ## Version 1.0.0 (2025-05-27) ## {#version-1.0.0}

--- a/specs/index.bs
+++ b/specs/index.bs
@@ -2209,6 +2209,22 @@ Note: Section [[#appendix-b-sf-example]] contains an example.
 
               See [[!PACTDX]] and the PACT Framework ([[!PACT-FRAMEWORK]]) for further details.
       <tr>
+        <td>CarbonFootprint
+        <td>`secondaryEmissionFactorSources`
+        <td>
+              If GLEC default or modeled values were used, this SHOULD be indicated in the emission factor sources
+              array, setting
+              - `"name"` to `"GLEC Framework"`
+              - `"version"` to the version used (version 3.0 is recommended)
+
+              For example:
+              <pre highlight='json'>
+                {
+                  "name": "GLEC Framework",
+                  "version": "3.0"
+                }
+              </pre>
+      <tr>
         <td>DataModelExtension
         <td>`specVersion`
         <td>
@@ -2385,6 +2401,22 @@ Note: Section [[#appendix-b-toc-example]] contains an example.
               The relative share of logistics emissions for whose calculation primary data has been used.
 
               See [[!PACTDX]] and the PACT Framework ([[!PACT-FRAMEWORK]]) for further details.
+      <tr>
+        <td>CarbonFootprint
+        <td>`secondaryEmissionFactorSources`
+        <td>
+              If GLEC default or modeled values were used, this SHOULD be indicated in the emission factor sources
+              array, setting
+              - `"name"` to `"GLEC Framework"`
+              - `"version"` to the version used (version 3.0 is recommended)
+
+              For example:
+              <pre highlight='json'>
+                {
+                  "name": "GLEC Framework",
+                  "version": "3.0"
+                }
+              </pre>
       <tr>
         <td>DataModelExtension
         <td>`specVersion`
@@ -2566,7 +2598,22 @@ Note: Section [[#appendix-b-hoc-example]] contains an example.
               The relative share of logistics emissions for whose calculation primary data has been used.
 
               See [[!PACTDX]] and the PACT Framework ([[!PACT-FRAMEWORK]]) for further details.
+      <tr>
+        <td>CarbonFootprint
+        <td>`secondaryEmissionFactorSources`
+        <td>
+              If GLEC default or modeled values were used, this SHOULD be indicated in the emission factor sources
+              array, setting
+              - `"name"` to `"GLEC Framework"`
+              - `"version"` to the version used (version 3.0 is recommended)
 
+              For example:
+              <pre highlight='json'>
+                {
+                  "name": "GLEC Framework",
+                  "version": "3.0"
+                }
+              </pre>
       <tr>
         <td>DataModelExtension
         <td>`specVersion`
@@ -2733,7 +2780,10 @@ apply for additional support, materials, and marketing opportunities.
 
 ## Version 1.0.1-28072025 (2025-07-28) ## {#version-1.0.1}
 
-Fix typo in <{Location}> properties table
+Summary of changes:
+- addition of guidance on `secondaryEmissionFactorSources` in [[#pcf-mapping-sf]],
+  [[#pcf-mapping-toc]], and [[#pcf-mapping-hoc]]
+- fix typo in <{Location}> properties table
 
 ## Version 1.0.0 (2025-05-27) ## {#version-1.0.0}
 

--- a/specs/index.bs
+++ b/specs/index.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: iLEAP Technical Specifications (Version 1.0.0)
+Title: iLEAP Technical Specifications (Version 1.0.1-28072025)
 Shortname: ileap-extension
 Status: LD
 Status Text: Technical Specification Pre-Release
@@ -1612,7 +1612,7 @@ Properties of data type <dfn element>Location</dfn>:
         <td>Longitude of the location.  If <{Location/lat}> is defined, so <{Location/lng}> MUST be defined.
 
     </table>
-    <figcaption><{GLECDistance}> properties</figcaption>
+    <figcaption><{Location}> properties</figcaption>
 </figure>
 
 
@@ -2730,6 +2730,10 @@ apply for additional support, materials, and marketing opportunities.
 
 
 # Appendix A: Changelog # {#changelog}
+
+## Version 1.0.1-28072025 (2025-07-28) ## {#version-1.0.1}
+
+Fix typo in <{Location}> properties table
 
 ## Version 1.0.0 (2025-05-27) ## {#version-1.0.0}
 


### PR DESCRIPTION
- addition of guidance on `secondaryEmissionFactorSources` in [[#pcf-mapping-sf]],
    [[#pcf-mapping-toc]], and [[#pcf-mapping-hoc]]
- addition on advisment on future methodological updates and their implications to [[#pcf-mapping]]
- fix typo in <{Location}> properties table
